### PR TITLE
Simplify release workflow and tagging

### DIFF
--- a/.github/workflows/ci-cd.workflow.yaml
+++ b/.github/workflows/ci-cd.workflow.yaml
@@ -188,7 +188,7 @@ jobs:
         with:
           repository: ovesorg/deployment-charts
           ref: ${{ steps.select_branch.outputs.branch }}
-          token: ${{env.REGISTRY_PASSWORD}}
+          token: ${{ secrets.GIT_TOKEN }}
       - name: Setup Git Config
         if: steps.select_branch.outputs.should_update == 'true'
         uses: jamie-codez/setup-git-user@v1

--- a/.github/workflows/ci-cd.workflow.yaml
+++ b/.github/workflows/ci-cd.workflow.yaml
@@ -142,7 +142,7 @@ jobs:
         id: create_release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ needs.semantic-release.outputs.git_tag }}-dev
+          tag_name: ${{ needs.semantic-release.outputs.git_tag }}
           body: ${{ needs.semantic-release.outputs.changelog }}
           draft: false
           prerelease: false

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -17,36 +17,10 @@
       "@semantic-release/github",
       {
         "assets": [
-          "package.json",
-          "README.md",
-          "CHANGELOG.md",
-          "SUPPORT.md",
-          "CODE_OF_CONDUCT.md",
-          "LICENSE",
-          "CONTRIBUTORS.md",
-          "CONTRIBUTING.md",
-          "GOVERNANCE.md",
-          "FUNDING.yml",
-          "manifest.json",
-          "public/manifest.json",
-          "DOCUMENTATION_SUMMARY.md",
-          "build"
+          "CHANGELOG.md"
         ],
         "releaseAssets": [
-          "package.json",
-          "README.md",
-          "CHANGELOG.md",
-          "SUPPORT.md",
-          "CODE_OF_CONDUCT.md",
-          "LICENSE",
-          "CONTRIBUTORS.md",
-          "CONTRIBUTING.md",
-          "GOVERNANCE.md",
-          "FUNDING.yml",
-          "manifest.json",
-          "public/manifest.json",
-          "DOCUMENTATION_SUMMARY.md",
-          "build"
+          "CHANGELOG.md"
         ],
         "token": "${env.GITHUB_TOKEN}",
         "releaseName": "${nextRelease.version}",
@@ -57,20 +31,7 @@
       "@semantic-release/git",
       {
         "assets": [
-          "package.json",
-          "README.md",
-          "CHANGELOG.md",
-          "SUPPORT.md",
-          "CODE_OF_CONDUCT.md",
-          "LICENSE",
-          "CONTRIBUTORS.md",
-          "CONTRIBUTING.md",
-          "GOVERNANCE.md",
-          "FUNDING.yml",
-          "manifest.json",
-          "public/manifest.json",
-          "DOCUMENTATION_SUMMARY.md",
-          "build"
+          "CHANGELOG.md"
         ],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
         "pushOptions": {


### PR DESCRIPTION
# Pull Request

## Description

This PR simplifies the release workflow and tagging process by making the following changes:
- Removed the `-dev` suffix from release tags for better clarity and adherence to standard release practices.
- Limited the asset list in `.releaserc.json` to only include `CHANGELOG.md` for a more streamlined configuration.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition/update
- [x] Configuration change

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes #
Relates to #

## Changes Made

-